### PR TITLE
#11 setup swagger ui

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,15 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.0.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
 		<dependency>

--- a/src/main/java/fom/pmse/crms/backend/controller/HealthCheckController.java
+++ b/src/main/java/fom/pmse/crms/backend/controller/HealthCheckController.java
@@ -1,16 +1,19 @@
 package fom.pmse.crms.backend.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 
-@Controller
+@RestController
 @RequestMapping(path = "/api/v1/health")
 public class HealthCheckController {
-    @GetMapping()
+    @GetMapping
+    @Operation(summary = "Perform a health check of the backend")
+    @ApiResponse(responseCode = "200", description = "The backend is healthy")
+    @ApiResponse(responseCode = "500", description = "The backend is not healthy")
     public ResponseEntity<String> performHealthCheck() {
         return ResponseEntity.ok("OK");
     }


### PR DESCRIPTION
### add swagger dependency and add documentation for HealthCheckController.

After starting the backend application, a web interface for the implemented rest endpoints will be available via `http://localhost:8080/swagger-ui/index.html`.

See the image below for an impression

<img width="1452" alt="image" src="https://user-images.githubusercontent.com/49094676/228312237-1e453a8e-a485-4bde-b748-30115f17c58f.png">

Closes #11 